### PR TITLE
Style UI like vintage HP calculators

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,8 +16,21 @@
 <body>
   <!-- HP-67 Calculator Body -->
   <div id="calculator-body">
-    <!-- Stack Display Area -->
-    <div id="stackDisplay">
+    <!-- HP Logo/Branding Area -->
+    <div id="hp-header">
+      <div class="hp-logo">
+        <span class="hp-letters">hp</span>
+      </div>
+      <div class="model-info">
+        <span class="model-name">67</span>
+        <span class="model-type">Programmable Scientific</span>
+      </div>
+    </div>
+
+    <!-- Metallic Bezel -->
+    <div id="display-bezel">
+      <!-- Stack Display Area -->
+      <div id="stackDisplay">
       <div class="stack-row">
         <div class="stack-label">T:</div>
         <div class="stack-value" id="stack-t">0</div>
@@ -40,10 +53,10 @@
         <div class="stack-value" id="stack-entry"></div>
       </div>
     </div>
+    </div>
 
-    <!-- HP-67 Calculator Keyboard -->
-    <div id="calcContainer">
-    <!-- HP-67 Calculator Keyboard -->
+    <!-- Keyboard Section with Gold Trim -->
+    <div id="keyboard-section">
     <div id="calcContainer">
       <!-- Row 1: Top function row -->
       <div class="button-row">
@@ -133,6 +146,7 @@
         <button class="opBtn" data-action="+">+</button>
         <button class="fnBtn" data-action="HMS">→H.MS</button>
       </div>
+    </div>
     </div>
   </div>
 

--- a/index.html
+++ b/index.html
@@ -104,8 +104,7 @@
         <button class="otherBtn" data-action="ROLL">R↓</button>
         <button class="otherBtn" data-action="LASTX">LAST x</button>
         <button class="otherBtn" data-action="CHS">CHS</button>
-        <button class="otherBtn" data-action="EEX">EEX</button>
-        <button class="otherBtn enter-btn" data-action="ENTER">ENTER ↑</button>
+        <button class="enter-btn" data-action="ENTER">ENTER ↓</button>
       </div>
       
       <!-- Row 6: 7, 8, 9, operations -->
@@ -144,7 +143,7 @@
         <button data-action="0" class="wide-btn">0</button>
         <button data-action=".">.</button>
         <button class="opBtn" data-action="+">+</button>
-        <button class="fnBtn" data-action="HMS">→H.MS</button>
+        <button class="otherBtn" data-action="EEX">EEX</button>
       </div>
     </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -142,8 +142,8 @@
         <button class="otherBtn" data-action="DEL">DEL</button>
         <button data-action="0" class="wide-btn">0</button>
         <button data-action=".">.</button>
-        <button class="opBtn" data-action="+">+</button>
         <button class="otherBtn" data-action="EEX">EEX</button>
+        <button class="opBtn" data-action="+">+</button>
       </div>
     </div>
     </div>

--- a/styles.css
+++ b/styles.css
@@ -182,8 +182,9 @@ body {
 .stack-row {
     display: flex;
     justify-content: space-between;
+    align-items: center;
     font-size: 15px;
-    line-height: 1.5;
+    height: 22px;
     position: relative;
     z-index: 1;
 }
@@ -208,6 +209,8 @@ body {
         0 0 8px rgba(255, 102, 0, 0.6),
         0 0 15px rgba(255, 60, 0, 0.3);
     letter-spacing: 1px;
+    line-height: 22px;
+    min-height: 22px;
 }
 
 /* Entry row - slightly dimmer */
@@ -249,19 +252,22 @@ body {
     border-top: 1px solid rgba(80, 70, 55, 0.4);
 }
 
-/* Base button styles - Classic HP beveled keys */
+/* Base button styles - Classic HP flat-top beveled keys */
 button {
     font-family: 'Roboto Condensed', 'Helvetica Neue', sans-serif;
     font-weight: 600;
     font-size: 11px;
-    background: linear-gradient(180deg,
-        #4a4540 0%,
-        #3a3530 40%,
-        #2a2520 60%,
-        #353025 100%);
+    background:
+        linear-gradient(180deg,
+            rgba(255, 255, 255, 0.12) 0%,
+            rgba(255, 255, 255, 0.05) 3%,
+            transparent 3%),
+        linear-gradient(180deg,
+            #3a3530 0%,
+            #353025 100%);
     color: #e8e0d0;
     border: none;
-    border-radius: 5px;
+    border-radius: 3px;
     width: 100%;
     height: 42px;
     cursor: pointer;
@@ -269,8 +275,10 @@ button {
     box-shadow:
         0 4px 0 #1a1815,
         0 5px 3px rgba(0, 0, 0, 0.4),
-        inset 0 1px 0 rgba(255, 255, 255, 0.12),
-        inset 0 -1px 0 rgba(0, 0, 0, 0.2);
+        inset 0 1px 0 rgba(255, 255, 255, 0.15),
+        inset 1px 0 0 rgba(255, 255, 255, 0.05),
+        inset -1px 0 0 rgba(0, 0, 0, 0.1),
+        inset 0 -1px 0 rgba(0, 0, 0, 0.3);
     text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
     transition: all 0.08s ease-out;
     padding: 0 3px;
@@ -279,25 +287,37 @@ button {
 }
 
 button:hover {
-    background: linear-gradient(180deg,
-        #555048 0%,
-        #454038 40%,
-        #353028 60%,
-        #403830 100%);
+    background:
+        linear-gradient(180deg,
+            rgba(255, 255, 255, 0.15) 0%,
+            rgba(255, 255, 255, 0.08) 3%,
+            transparent 3%),
+        linear-gradient(180deg,
+            #454038 0%,
+            #403830 100%);
     box-shadow:
         0 4px 0 #1a1815,
         0 6px 5px rgba(0, 0, 0, 0.5),
-        inset 0 1px 0 rgba(255, 255, 255, 0.15),
-        inset 0 -1px 0 rgba(0, 0, 0, 0.2);
+        inset 0 1px 0 rgba(255, 255, 255, 0.18),
+        inset 1px 0 0 rgba(255, 255, 255, 0.06),
+        inset -1px 0 0 rgba(0, 0, 0, 0.1),
+        inset 0 -1px 0 rgba(0, 0, 0, 0.3);
 }
 
 button:active {
     transform: translateY(3px);
+    background:
+        linear-gradient(180deg,
+            rgba(0, 0, 0, 0.1) 0%,
+            transparent 5%),
+        linear-gradient(180deg,
+            #302a25 0%,
+            #2a2520 100%);
     box-shadow:
         0 1px 0 #1a1815,
         0 2px 2px rgba(0, 0, 0, 0.3),
-        inset 0 1px 0 rgba(255, 255, 255, 0.08),
-        inset 0 2px 4px rgba(0, 0, 0, 0.2);
+        inset 0 1px 0 rgba(0, 0, 0, 0.1),
+        inset 0 2px 4px rgba(0, 0, 0, 0.15);
 }
 
 /* Math notation styling */
@@ -323,11 +343,12 @@ button[data-action="7"],
 button[data-action="8"],
 button[data-action="9"],
 button[data-action="."] {
-    background: linear-gradient(180deg,
-        #5a5550 0%,
-        #4a4540 40%,
-        #3a3530 60%,
-        #454035 100%);
+    background:
+        linear-gradient(180deg,
+            rgba(255, 255, 255, 0.15) 0%,
+            rgba(255, 255, 255, 0.06) 3%,
+            transparent 3%),
+        linear-gradient(180deg, #4a4540 0%, #454035 100%);
     color: #ffffff;
     font-weight: 700;
     font-size: 14px;
@@ -344,20 +365,22 @@ button[data-action="7"]:hover,
 button[data-action="8"]:hover,
 button[data-action="9"]:hover,
 button[data-action="."]:hover {
-    background: linear-gradient(180deg,
-        #656055 0%,
-        #555048 40%,
-        #454038 60%,
-        #504840 100%);
+    background:
+        linear-gradient(180deg,
+            rgba(255, 255, 255, 0.18) 0%,
+            rgba(255, 255, 255, 0.08) 3%,
+            transparent 3%),
+        linear-gradient(180deg, #555048 0%, #504840 100%);
 }
 
 /* Operation buttons - Gold/Brown HP style */
 .opBtn {
-    background: linear-gradient(180deg,
-        #8a7040 0%,
-        #705828 40%,
-        #5a4820 60%,
-        #6a5830 100%);
+    background:
+        linear-gradient(180deg,
+            rgba(255, 240, 200, 0.2) 0%,
+            rgba(255, 240, 200, 0.08) 3%,
+            transparent 3%),
+        linear-gradient(180deg, #6a5828 0%, #5a4820 100%);
     color: #fff8e0;
     font-weight: 700;
     font-size: 16px;
@@ -365,150 +388,194 @@ button[data-action="."]:hover {
     box-shadow:
         0 4px 0 #3a3020,
         0 5px 3px rgba(0, 0, 0, 0.4),
-        inset 0 1px 0 rgba(255, 255, 255, 0.2),
-        inset 0 -1px 0 rgba(0, 0, 0, 0.2);
+        inset 0 1px 0 rgba(255, 240, 200, 0.25),
+        inset 1px 0 0 rgba(255, 240, 200, 0.08),
+        inset -1px 0 0 rgba(0, 0, 0, 0.15),
+        inset 0 -1px 0 rgba(0, 0, 0, 0.3);
 }
 
 .opBtn:hover {
-    background: linear-gradient(180deg,
-        #9a8050 0%,
-        #806838 40%,
-        #6a5830 60%,
-        #7a6840 100%);
+    background:
+        linear-gradient(180deg,
+            rgba(255, 240, 200, 0.25) 0%,
+            rgba(255, 240, 200, 0.1) 3%,
+            transparent 3%),
+        linear-gradient(180deg, #7a6838 0%, #6a5830 100%);
     box-shadow:
         0 4px 0 #3a3020,
         0 6px 5px rgba(0, 0, 0, 0.5),
-        inset 0 1px 0 rgba(255, 255, 255, 0.25),
-        inset 0 -1px 0 rgba(0, 0, 0, 0.2);
+        inset 0 1px 0 rgba(255, 240, 200, 0.3),
+        inset 1px 0 0 rgba(255, 240, 200, 0.1),
+        inset -1px 0 0 rgba(0, 0, 0, 0.15),
+        inset 0 -1px 0 rgba(0, 0, 0, 0.3);
 }
 
 .opBtn:active {
+    background:
+        linear-gradient(180deg,
+            rgba(0, 0, 0, 0.1) 0%,
+            transparent 5%),
+        linear-gradient(180deg, #504018 0%, #4a3818 100%);
     box-shadow:
         0 1px 0 #3a3020,
         0 2px 2px rgba(0, 0, 0, 0.3),
-        inset 0 1px 0 rgba(255, 255, 255, 0.1),
-        inset 0 2px 4px rgba(0, 0, 0, 0.2);
+        inset 0 1px 0 rgba(0, 0, 0, 0.1),
+        inset 0 2px 4px rgba(0, 0, 0, 0.15);
 }
 
 /* Function buttons - Olive/Khaki HP style */
 .fnBtn {
-    background: linear-gradient(180deg,
-        #605838 0%,
-        #504828 40%,
-        #403820 60%,
-        #4a4228 100%);
+    background:
+        linear-gradient(180deg,
+            rgba(230, 230, 150, 0.15) 0%,
+            rgba(230, 230, 150, 0.05) 3%,
+            transparent 3%),
+        linear-gradient(180deg, #504828 0%, #4a4220 100%);
     color: #e8e080;
     font-weight: 600;
     box-shadow:
         0 4px 0 #282418,
         0 5px 3px rgba(0, 0, 0, 0.4),
-        inset 0 1px 0 rgba(255, 255, 255, 0.12),
-        inset 0 -1px 0 rgba(0, 0, 0, 0.2);
+        inset 0 1px 0 rgba(230, 230, 150, 0.18),
+        inset 1px 0 0 rgba(230, 230, 150, 0.06),
+        inset -1px 0 0 rgba(0, 0, 0, 0.12),
+        inset 0 -1px 0 rgba(0, 0, 0, 0.3);
 }
 
 .fnBtn:hover {
-    background: linear-gradient(180deg,
-        #706848 0%,
-        #605838 40%,
-        #504830 60%,
-        #5a5238 100%);
+    background:
+        linear-gradient(180deg,
+            rgba(230, 230, 150, 0.2) 0%,
+            rgba(230, 230, 150, 0.08) 3%,
+            transparent 3%),
+        linear-gradient(180deg, #605838 0%, #5a5230 100%);
     box-shadow:
         0 4px 0 #282418,
         0 6px 5px rgba(0, 0, 0, 0.5),
-        inset 0 1px 0 rgba(255, 255, 255, 0.15),
-        inset 0 -1px 0 rgba(0, 0, 0, 0.2);
+        inset 0 1px 0 rgba(230, 230, 150, 0.22),
+        inset 1px 0 0 rgba(230, 230, 150, 0.08),
+        inset -1px 0 0 rgba(0, 0, 0, 0.12),
+        inset 0 -1px 0 rgba(0, 0, 0, 0.3);
 }
 
 .fnBtn:active {
+    background:
+        linear-gradient(180deg,
+            rgba(0, 0, 0, 0.1) 0%,
+            transparent 5%),
+        linear-gradient(180deg, #403818 0%, #3a3418 100%);
     box-shadow:
         0 1px 0 #282418,
         0 2px 2px rgba(0, 0, 0, 0.3),
-        inset 0 1px 0 rgba(255, 255, 255, 0.08),
-        inset 0 2px 4px rgba(0, 0, 0, 0.2);
+        inset 0 1px 0 rgba(0, 0, 0, 0.1),
+        inset 0 2px 4px rgba(0, 0, 0, 0.15);
 }
 
 /* Memory buttons - Blue HP style */
 .memBtn {
-    background: linear-gradient(180deg,
-        #3a5068 0%,
-        #2a4058 40%,
-        #203048 60%,
-        #2a3a50 100%);
+    background:
+        linear-gradient(180deg,
+            rgba(150, 200, 255, 0.18) 0%,
+            rgba(150, 200, 255, 0.06) 3%,
+            transparent 3%),
+        linear-gradient(180deg, #2a4058 0%, #253850 100%);
     color: #90d0ff;
     font-weight: 600;
     box-shadow:
         0 4px 0 #152030,
         0 5px 3px rgba(0, 0, 0, 0.4),
-        inset 0 1px 0 rgba(255, 255, 255, 0.12),
-        inset 0 -1px 0 rgba(0, 0, 0, 0.2);
+        inset 0 1px 0 rgba(150, 200, 255, 0.2),
+        inset 1px 0 0 rgba(150, 200, 255, 0.06),
+        inset -1px 0 0 rgba(0, 0, 0, 0.15),
+        inset 0 -1px 0 rgba(0, 0, 0, 0.3);
 }
 
 .memBtn:hover {
-    background: linear-gradient(180deg,
-        #4a6078 0%,
-        #3a5068 40%,
-        #304058 60%,
-        #3a4a60 100%);
+    background:
+        linear-gradient(180deg,
+            rgba(150, 200, 255, 0.22) 0%,
+            rgba(150, 200, 255, 0.08) 3%,
+            transparent 3%),
+        linear-gradient(180deg, #3a5068 0%, #354860 100%);
     box-shadow:
         0 4px 0 #152030,
         0 6px 5px rgba(0, 0, 0, 0.5),
-        inset 0 1px 0 rgba(255, 255, 255, 0.15),
-        inset 0 -1px 0 rgba(0, 0, 0, 0.2);
+        inset 0 1px 0 rgba(150, 200, 255, 0.25),
+        inset 1px 0 0 rgba(150, 200, 255, 0.08),
+        inset -1px 0 0 rgba(0, 0, 0, 0.15),
+        inset 0 -1px 0 rgba(0, 0, 0, 0.3);
 }
 
 .memBtn:active {
+    background:
+        linear-gradient(180deg,
+            rgba(0, 0, 0, 0.1) 0%,
+            transparent 5%),
+        linear-gradient(180deg, #203048 0%, #1a2840 100%);
     box-shadow:
         0 1px 0 #152030,
         0 2px 2px rgba(0, 0, 0, 0.3),
-        inset 0 1px 0 rgba(255, 255, 255, 0.08),
-        inset 0 2px 4px rgba(0, 0, 0, 0.2);
+        inset 0 1px 0 rgba(0, 0, 0, 0.1),
+        inset 0 2px 4px rgba(0, 0, 0, 0.15);
 }
 
 /* Other/Stack operation buttons - Tan/Brown */
 .otherBtn {
-    background: linear-gradient(180deg,
-        #5a4838 0%,
-        #4a3828 40%,
-        #3a2820 60%,
-        #443228 100%);
+    background:
+        linear-gradient(180deg,
+            rgba(255, 200, 150, 0.15) 0%,
+            rgba(255, 200, 150, 0.05) 3%,
+            transparent 3%),
+        linear-gradient(180deg, #4a3828 0%, #443020 100%);
     color: #ffcc88;
     font-weight: 600;
     font-size: 10px;
     box-shadow:
         0 4px 0 #201810,
         0 5px 3px rgba(0, 0, 0, 0.4),
-        inset 0 1px 0 rgba(255, 255, 255, 0.12),
-        inset 0 -1px 0 rgba(0, 0, 0, 0.2);
+        inset 0 1px 0 rgba(255, 200, 150, 0.18),
+        inset 1px 0 0 rgba(255, 200, 150, 0.06),
+        inset -1px 0 0 rgba(0, 0, 0, 0.12),
+        inset 0 -1px 0 rgba(0, 0, 0, 0.3);
 }
 
 .otherBtn:hover {
-    background: linear-gradient(180deg,
-        #6a5848 0%,
-        #5a4838 40%,
-        #4a3830 60%,
-        #544238 100%);
+    background:
+        linear-gradient(180deg,
+            rgba(255, 200, 150, 0.2) 0%,
+            rgba(255, 200, 150, 0.08) 3%,
+            transparent 3%),
+        linear-gradient(180deg, #5a4838 0%, #544030 100%);
     box-shadow:
         0 4px 0 #201810,
         0 6px 5px rgba(0, 0, 0, 0.5),
-        inset 0 1px 0 rgba(255, 255, 255, 0.15),
-        inset 0 -1px 0 rgba(0, 0, 0, 0.2);
+        inset 0 1px 0 rgba(255, 200, 150, 0.22),
+        inset 1px 0 0 rgba(255, 200, 150, 0.08),
+        inset -1px 0 0 rgba(0, 0, 0, 0.12),
+        inset 0 -1px 0 rgba(0, 0, 0, 0.3);
 }
 
 .otherBtn:active {
+    background:
+        linear-gradient(180deg,
+            rgba(0, 0, 0, 0.1) 0%,
+            transparent 5%),
+        linear-gradient(180deg, #3a2818 0%, #342418 100%);
     box-shadow:
         0 1px 0 #201810,
         0 2px 2px rgba(0, 0, 0, 0.3),
-        inset 0 1px 0 rgba(255, 255, 255, 0.08),
-        inset 0 2px 4px rgba(0, 0, 0, 0.2);
+        inset 0 1px 0 rgba(0, 0, 0, 0.1),
+        inset 0 2px 4px rgba(0, 0, 0, 0.15);
 }
 
 /* ENTER button - Special gold highlight */
 .enter-btn {
-    background: linear-gradient(180deg,
-        #7a6238 0%,
-        #604a20 40%,
-        #503a18 60%,
-        #5a4420 100%);
+    background:
+        linear-gradient(180deg,
+            rgba(255, 230, 160, 0.22) 0%,
+            rgba(255, 230, 160, 0.08) 3%,
+            transparent 3%),
+        linear-gradient(180deg, #5a4820 0%, #504018 100%);
     color: #ffe8a0;
     font-weight: 700;
     font-size: 10px;
@@ -516,16 +583,39 @@ button[data-action="."]:hover {
     box-shadow:
         0 4px 0 #302810,
         0 5px 3px rgba(0, 0, 0, 0.4),
-        inset 0 1px 0 rgba(255, 255, 255, 0.18),
-        inset 0 -1px 0 rgba(0, 0, 0, 0.2);
+        inset 0 1px 0 rgba(255, 230, 160, 0.25),
+        inset 1px 0 0 rgba(255, 230, 160, 0.08),
+        inset -1px 0 0 rgba(0, 0, 0, 0.15),
+        inset 0 -1px 0 rgba(0, 0, 0, 0.3);
 }
 
 .enter-btn:hover {
-    background: linear-gradient(180deg,
-        #8a7248 0%,
-        #705a30 40%,
-        #604a28 60%,
-        #6a5430 100%);
+    background:
+        linear-gradient(180deg,
+            rgba(255, 230, 160, 0.28) 0%,
+            rgba(255, 230, 160, 0.1) 3%,
+            transparent 3%),
+        linear-gradient(180deg, #6a5830 0%, #604828 100%);
+    box-shadow:
+        0 4px 0 #302810,
+        0 6px 5px rgba(0, 0, 0, 0.5),
+        inset 0 1px 0 rgba(255, 230, 160, 0.3),
+        inset 1px 0 0 rgba(255, 230, 160, 0.1),
+        inset -1px 0 0 rgba(0, 0, 0, 0.15),
+        inset 0 -1px 0 rgba(0, 0, 0, 0.3);
+}
+
+.enter-btn:active {
+    background:
+        linear-gradient(180deg,
+            rgba(0, 0, 0, 0.1) 0%,
+            transparent 5%),
+        linear-gradient(180deg, #4a3818 0%, #443010 100%);
+    box-shadow:
+        0 1px 0 #302810,
+        0 2px 2px rgba(0, 0, 0, 0.3),
+        inset 0 1px 0 rgba(0, 0, 0, 0.1),
+        inset 0 2px 4px rgba(0, 0, 0, 0.15);
 }
 
 /* Wide button styling */

--- a/styles.css
+++ b/styles.css
@@ -256,15 +256,8 @@ body {
 button {
     font-family: 'Roboto Condensed', 'Helvetica Neue', sans-serif;
     font-weight: 600;
-    font-size: 11px;
-    background:
-        linear-gradient(180deg,
-            rgba(255, 255, 255, 0.12) 0%,
-            rgba(255, 255, 255, 0.05) 3%,
-            transparent 3%),
-        linear-gradient(180deg,
-            #3a3530 0%,
-            #353025 100%);
+    font-size: 12px;
+    background: #383330;
     color: #e8e0d0;
     border: none;
     border-radius: 3px;
@@ -273,12 +266,17 @@ button {
     cursor: pointer;
     margin: 0;
     box-shadow:
+        /* 3D depth - bottom edge */
         0 4px 0 #1a1815,
         0 5px 3px rgba(0, 0, 0, 0.4),
-        inset 0 1px 0 rgba(255, 255, 255, 0.15),
-        inset 1px 0 0 rgba(255, 255, 255, 0.05),
-        inset -1px 0 0 rgba(0, 0, 0, 0.1),
-        inset 0 -1px 0 rgba(0, 0, 0, 0.3);
+        /* Top chamfer highlight */
+        inset 0 2px 0 rgba(255, 255, 255, 0.12),
+        /* Left chamfer highlight */
+        inset 2px 0 0 rgba(255, 255, 255, 0.06),
+        /* Right chamfer shadow */
+        inset -2px 0 0 rgba(0, 0, 0, 0.15),
+        /* Bottom chamfer shadow */
+        inset 0 -2px 0 rgba(0, 0, 0, 0.25);
     text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
     transition: all 0.08s ease-out;
     padding: 0 3px;
@@ -287,37 +285,26 @@ button {
 }
 
 button:hover {
-    background:
-        linear-gradient(180deg,
-            rgba(255, 255, 255, 0.15) 0%,
-            rgba(255, 255, 255, 0.08) 3%,
-            transparent 3%),
-        linear-gradient(180deg,
-            #454038 0%,
-            #403830 100%);
+    background: #454038;
     box-shadow:
         0 4px 0 #1a1815,
         0 6px 5px rgba(0, 0, 0, 0.5),
-        inset 0 1px 0 rgba(255, 255, 255, 0.18),
-        inset 1px 0 0 rgba(255, 255, 255, 0.06),
-        inset -1px 0 0 rgba(0, 0, 0, 0.1),
-        inset 0 -1px 0 rgba(0, 0, 0, 0.3);
+        inset 0 2px 0 rgba(255, 255, 255, 0.15),
+        inset 2px 0 0 rgba(255, 255, 255, 0.08),
+        inset -2px 0 0 rgba(0, 0, 0, 0.15),
+        inset 0 -2px 0 rgba(0, 0, 0, 0.25);
 }
 
 button:active {
     transform: translateY(3px);
-    background:
-        linear-gradient(180deg,
-            rgba(0, 0, 0, 0.1) 0%,
-            transparent 5%),
-        linear-gradient(180deg,
-            #302a25 0%,
-            #2a2520 100%);
+    background: #2a2520;
     box-shadow:
         0 1px 0 #1a1815,
         0 2px 2px rgba(0, 0, 0, 0.3),
-        inset 0 1px 0 rgba(0, 0, 0, 0.1),
-        inset 0 2px 4px rgba(0, 0, 0, 0.15);
+        inset 0 2px 3px rgba(0, 0, 0, 0.2),
+        inset 2px 0 0 rgba(0, 0, 0, 0.1),
+        inset -2px 0 0 rgba(0, 0, 0, 0.1),
+        inset 0 -1px 0 rgba(255, 255, 255, 0.05);
 }
 
 /* Math notation styling */
@@ -343,15 +330,17 @@ button[data-action="7"],
 button[data-action="8"],
 button[data-action="9"],
 button[data-action="."] {
-    background:
-        linear-gradient(180deg,
-            rgba(255, 255, 255, 0.15) 0%,
-            rgba(255, 255, 255, 0.06) 3%,
-            transparent 3%),
-        linear-gradient(180deg, #4a4540 0%, #454035 100%);
+    background: #484440;
     color: #ffffff;
     font-weight: 700;
-    font-size: 14px;
+    font-size: 16px;
+    box-shadow:
+        0 4px 0 #1a1815,
+        0 5px 3px rgba(0, 0, 0, 0.4),
+        inset 0 2px 0 rgba(255, 255, 255, 0.15),
+        inset 2px 0 0 rgba(255, 255, 255, 0.08),
+        inset -2px 0 0 rgba(0, 0, 0, 0.12),
+        inset 0 -2px 0 rgba(0, 0, 0, 0.2);
 }
 
 button[data-action="0"]:hover,
@@ -365,257 +354,160 @@ button[data-action="7"]:hover,
 button[data-action="8"]:hover,
 button[data-action="9"]:hover,
 button[data-action="."]:hover {
-    background:
-        linear-gradient(180deg,
-            rgba(255, 255, 255, 0.18) 0%,
-            rgba(255, 255, 255, 0.08) 3%,
-            transparent 3%),
-        linear-gradient(180deg, #555048 0%, #504840 100%);
+    background: #555048;
 }
 
 /* Operation buttons - Gold/Brown HP style */
 .opBtn {
-    background:
-        linear-gradient(180deg,
-            rgba(255, 240, 200, 0.2) 0%,
-            rgba(255, 240, 200, 0.08) 3%,
-            transparent 3%),
-        linear-gradient(180deg, #6a5828 0%, #5a4820 100%);
+    background: #5a4820;
     color: #fff8e0;
     font-weight: 700;
-    font-size: 16px;
+    font-size: 18px;
     text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
     box-shadow:
-        0 4px 0 #3a3020,
+        0 4px 0 #3a3018,
         0 5px 3px rgba(0, 0, 0, 0.4),
-        inset 0 1px 0 rgba(255, 240, 200, 0.25),
-        inset 1px 0 0 rgba(255, 240, 200, 0.08),
-        inset -1px 0 0 rgba(0, 0, 0, 0.15),
-        inset 0 -1px 0 rgba(0, 0, 0, 0.3);
+        inset 0 2px 0 rgba(255, 230, 180, 0.2),
+        inset 2px 0 0 rgba(255, 230, 180, 0.1),
+        inset -2px 0 0 rgba(0, 0, 0, 0.2),
+        inset 0 -2px 0 rgba(0, 0, 0, 0.3);
 }
 
 .opBtn:hover {
-    background:
-        linear-gradient(180deg,
-            rgba(255, 240, 200, 0.25) 0%,
-            rgba(255, 240, 200, 0.1) 3%,
-            transparent 3%),
-        linear-gradient(180deg, #7a6838 0%, #6a5830 100%);
-    box-shadow:
-        0 4px 0 #3a3020,
-        0 6px 5px rgba(0, 0, 0, 0.5),
-        inset 0 1px 0 rgba(255, 240, 200, 0.3),
-        inset 1px 0 0 rgba(255, 240, 200, 0.1),
-        inset -1px 0 0 rgba(0, 0, 0, 0.15),
-        inset 0 -1px 0 rgba(0, 0, 0, 0.3);
+    background: #6a5830;
 }
 
 .opBtn:active {
-    background:
-        linear-gradient(180deg,
-            rgba(0, 0, 0, 0.1) 0%,
-            transparent 5%),
-        linear-gradient(180deg, #504018 0%, #4a3818 100%);
+    background: #4a3818;
     box-shadow:
-        0 1px 0 #3a3020,
+        0 1px 0 #3a3018,
         0 2px 2px rgba(0, 0, 0, 0.3),
-        inset 0 1px 0 rgba(0, 0, 0, 0.1),
-        inset 0 2px 4px rgba(0, 0, 0, 0.15);
+        inset 0 2px 3px rgba(0, 0, 0, 0.2),
+        inset 2px 0 0 rgba(0, 0, 0, 0.1),
+        inset -2px 0 0 rgba(0, 0, 0, 0.1),
+        inset 0 -1px 0 rgba(255, 230, 180, 0.05);
 }
 
 /* Function buttons - Olive/Khaki HP style */
 .fnBtn {
-    background:
-        linear-gradient(180deg,
-            rgba(230, 230, 150, 0.15) 0%,
-            rgba(230, 230, 150, 0.05) 3%,
-            transparent 3%),
-        linear-gradient(180deg, #504828 0%, #4a4220 100%);
+    background: #4a4220;
     color: #e8e080;
     font-weight: 600;
+    font-size: 12px;
     box-shadow:
         0 4px 0 #282418,
         0 5px 3px rgba(0, 0, 0, 0.4),
-        inset 0 1px 0 rgba(230, 230, 150, 0.18),
-        inset 1px 0 0 rgba(230, 230, 150, 0.06),
-        inset -1px 0 0 rgba(0, 0, 0, 0.12),
-        inset 0 -1px 0 rgba(0, 0, 0, 0.3);
+        inset 0 2px 0 rgba(220, 220, 140, 0.15),
+        inset 2px 0 0 rgba(220, 220, 140, 0.08),
+        inset -2px 0 0 rgba(0, 0, 0, 0.18),
+        inset 0 -2px 0 rgba(0, 0, 0, 0.28);
 }
 
 .fnBtn:hover {
-    background:
-        linear-gradient(180deg,
-            rgba(230, 230, 150, 0.2) 0%,
-            rgba(230, 230, 150, 0.08) 3%,
-            transparent 3%),
-        linear-gradient(180deg, #605838 0%, #5a5230 100%);
-    box-shadow:
-        0 4px 0 #282418,
-        0 6px 5px rgba(0, 0, 0, 0.5),
-        inset 0 1px 0 rgba(230, 230, 150, 0.22),
-        inset 1px 0 0 rgba(230, 230, 150, 0.08),
-        inset -1px 0 0 rgba(0, 0, 0, 0.12),
-        inset 0 -1px 0 rgba(0, 0, 0, 0.3);
+    background: #5a5230;
 }
 
 .fnBtn:active {
-    background:
-        linear-gradient(180deg,
-            rgba(0, 0, 0, 0.1) 0%,
-            transparent 5%),
-        linear-gradient(180deg, #403818 0%, #3a3418 100%);
+    background: #3a3418;
     box-shadow:
         0 1px 0 #282418,
         0 2px 2px rgba(0, 0, 0, 0.3),
-        inset 0 1px 0 rgba(0, 0, 0, 0.1),
-        inset 0 2px 4px rgba(0, 0, 0, 0.15);
+        inset 0 2px 3px rgba(0, 0, 0, 0.2),
+        inset 2px 0 0 rgba(0, 0, 0, 0.1),
+        inset -2px 0 0 rgba(0, 0, 0, 0.1),
+        inset 0 -1px 0 rgba(220, 220, 140, 0.05);
 }
 
 /* Memory buttons - Blue HP style */
 .memBtn {
-    background:
-        linear-gradient(180deg,
-            rgba(150, 200, 255, 0.18) 0%,
-            rgba(150, 200, 255, 0.06) 3%,
-            transparent 3%),
-        linear-gradient(180deg, #2a4058 0%, #253850 100%);
+    background: #283850;
     color: #90d0ff;
     font-weight: 600;
+    font-size: 12px;
     box-shadow:
         0 4px 0 #152030,
         0 5px 3px rgba(0, 0, 0, 0.4),
-        inset 0 1px 0 rgba(150, 200, 255, 0.2),
-        inset 1px 0 0 rgba(150, 200, 255, 0.06),
-        inset -1px 0 0 rgba(0, 0, 0, 0.15),
-        inset 0 -1px 0 rgba(0, 0, 0, 0.3);
+        inset 0 2px 0 rgba(140, 190, 255, 0.15),
+        inset 2px 0 0 rgba(140, 190, 255, 0.08),
+        inset -2px 0 0 rgba(0, 0, 0, 0.2),
+        inset 0 -2px 0 rgba(0, 0, 0, 0.3);
 }
 
 .memBtn:hover {
-    background:
-        linear-gradient(180deg,
-            rgba(150, 200, 255, 0.22) 0%,
-            rgba(150, 200, 255, 0.08) 3%,
-            transparent 3%),
-        linear-gradient(180deg, #3a5068 0%, #354860 100%);
-    box-shadow:
-        0 4px 0 #152030,
-        0 6px 5px rgba(0, 0, 0, 0.5),
-        inset 0 1px 0 rgba(150, 200, 255, 0.25),
-        inset 1px 0 0 rgba(150, 200, 255, 0.08),
-        inset -1px 0 0 rgba(0, 0, 0, 0.15),
-        inset 0 -1px 0 rgba(0, 0, 0, 0.3);
+    background: #384860;
 }
 
 .memBtn:active {
-    background:
-        linear-gradient(180deg,
-            rgba(0, 0, 0, 0.1) 0%,
-            transparent 5%),
-        linear-gradient(180deg, #203048 0%, #1a2840 100%);
+    background: #1a2840;
     box-shadow:
         0 1px 0 #152030,
         0 2px 2px rgba(0, 0, 0, 0.3),
-        inset 0 1px 0 rgba(0, 0, 0, 0.1),
-        inset 0 2px 4px rgba(0, 0, 0, 0.15);
+        inset 0 2px 3px rgba(0, 0, 0, 0.2),
+        inset 2px 0 0 rgba(0, 0, 0, 0.1),
+        inset -2px 0 0 rgba(0, 0, 0, 0.1),
+        inset 0 -1px 0 rgba(140, 190, 255, 0.05);
 }
 
 /* Other/Stack operation buttons - Tan/Brown */
 .otherBtn {
-    background:
-        linear-gradient(180deg,
-            rgba(255, 200, 150, 0.15) 0%,
-            rgba(255, 200, 150, 0.05) 3%,
-            transparent 3%),
-        linear-gradient(180deg, #4a3828 0%, #443020 100%);
+    background: #443020;
     color: #ffcc88;
     font-weight: 600;
-    font-size: 10px;
+    font-size: 11px;
     box-shadow:
         0 4px 0 #201810,
         0 5px 3px rgba(0, 0, 0, 0.4),
-        inset 0 1px 0 rgba(255, 200, 150, 0.18),
-        inset 1px 0 0 rgba(255, 200, 150, 0.06),
-        inset -1px 0 0 rgba(0, 0, 0, 0.12),
-        inset 0 -1px 0 rgba(0, 0, 0, 0.3);
+        inset 0 2px 0 rgba(255, 200, 150, 0.15),
+        inset 2px 0 0 rgba(255, 200, 150, 0.08),
+        inset -2px 0 0 rgba(0, 0, 0, 0.18),
+        inset 0 -2px 0 rgba(0, 0, 0, 0.28);
 }
 
 .otherBtn:hover {
-    background:
-        linear-gradient(180deg,
-            rgba(255, 200, 150, 0.2) 0%,
-            rgba(255, 200, 150, 0.08) 3%,
-            transparent 3%),
-        linear-gradient(180deg, #5a4838 0%, #544030 100%);
-    box-shadow:
-        0 4px 0 #201810,
-        0 6px 5px rgba(0, 0, 0, 0.5),
-        inset 0 1px 0 rgba(255, 200, 150, 0.22),
-        inset 1px 0 0 rgba(255, 200, 150, 0.08),
-        inset -1px 0 0 rgba(0, 0, 0, 0.12),
-        inset 0 -1px 0 rgba(0, 0, 0, 0.3);
+    background: #544030;
 }
 
 .otherBtn:active {
-    background:
-        linear-gradient(180deg,
-            rgba(0, 0, 0, 0.1) 0%,
-            transparent 5%),
-        linear-gradient(180deg, #3a2818 0%, #342418 100%);
+    background: #342418;
     box-shadow:
         0 1px 0 #201810,
         0 2px 2px rgba(0, 0, 0, 0.3),
-        inset 0 1px 0 rgba(0, 0, 0, 0.1),
-        inset 0 2px 4px rgba(0, 0, 0, 0.15);
+        inset 0 2px 3px rgba(0, 0, 0, 0.2),
+        inset 2px 0 0 rgba(0, 0, 0, 0.1),
+        inset -2px 0 0 rgba(0, 0, 0, 0.1),
+        inset 0 -1px 0 rgba(255, 200, 150, 0.05);
 }
 
-/* ENTER button - Special gold highlight */
+/* ENTER button - Special gold highlight, double-width */
 .enter-btn {
-    background:
-        linear-gradient(180deg,
-            rgba(255, 230, 160, 0.22) 0%,
-            rgba(255, 230, 160, 0.08) 3%,
-            transparent 3%),
-        linear-gradient(180deg, #5a4820 0%, #504018 100%);
+    grid-column: span 2;
+    background: #5a4820;
     color: #ffe8a0;
     font-weight: 700;
-    font-size: 10px;
-    letter-spacing: 0.3px;
+    font-size: 13px;
+    letter-spacing: 0.5px;
     box-shadow:
-        0 4px 0 #302810,
+        0 4px 0 #3a3018,
         0 5px 3px rgba(0, 0, 0, 0.4),
-        inset 0 1px 0 rgba(255, 230, 160, 0.25),
-        inset 1px 0 0 rgba(255, 230, 160, 0.08),
-        inset -1px 0 0 rgba(0, 0, 0, 0.15),
-        inset 0 -1px 0 rgba(0, 0, 0, 0.3);
+        inset 0 2px 0 rgba(255, 220, 160, 0.2),
+        inset 2px 0 0 rgba(255, 220, 160, 0.1),
+        inset -2px 0 0 rgba(0, 0, 0, 0.2),
+        inset 0 -2px 0 rgba(0, 0, 0, 0.3);
 }
 
 .enter-btn:hover {
-    background:
-        linear-gradient(180deg,
-            rgba(255, 230, 160, 0.28) 0%,
-            rgba(255, 230, 160, 0.1) 3%,
-            transparent 3%),
-        linear-gradient(180deg, #6a5830 0%, #604828 100%);
-    box-shadow:
-        0 4px 0 #302810,
-        0 6px 5px rgba(0, 0, 0, 0.5),
-        inset 0 1px 0 rgba(255, 230, 160, 0.3),
-        inset 1px 0 0 rgba(255, 230, 160, 0.1),
-        inset -1px 0 0 rgba(0, 0, 0, 0.15),
-        inset 0 -1px 0 rgba(0, 0, 0, 0.3);
+    background: #6a5830;
 }
 
 .enter-btn:active {
-    background:
-        linear-gradient(180deg,
-            rgba(0, 0, 0, 0.1) 0%,
-            transparent 5%),
-        linear-gradient(180deg, #4a3818 0%, #443010 100%);
+    background: #4a3818;
     box-shadow:
-        0 1px 0 #302810,
+        0 1px 0 #3a3018,
         0 2px 2px rgba(0, 0, 0, 0.3),
-        inset 0 1px 0 rgba(0, 0, 0, 0.1),
-        inset 0 2px 4px rgba(0, 0, 0, 0.15);
+        inset 0 2px 3px rgba(0, 0, 0, 0.2),
+        inset 2px 0 0 rgba(0, 0, 0, 0.1),
+        inset -2px 0 0 rgba(0, 0, 0, 0.1),
+        inset 0 -1px 0 rgba(255, 220, 160, 0.05);
 }
 
 /* Wide button styling */

--- a/styles.css
+++ b/styles.css
@@ -1,81 +1,238 @@
+/* Vintage HP Calculator Styles */
+
+/* Import classic fonts */
+@import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@400;500;700&display=swap');
+
 /* General Page Styles */
 body {
-    background-color: #1a1a1a;
-    margin: 20px auto;
-    max-width: 550px;
-    padding: 20px;
+    background: linear-gradient(180deg, #1a1612 0%, #0d0a08 100%);
+    margin: 0;
+    padding: 30px 20px;
+    min-height: 100vh;
     box-sizing: border-box;
+    display: flex;
+    justify-content: center;
+    align-items: flex-start;
 }
 
-/* HP-67 Calculator Body - encompasses both display and keys */
+/* HP-67 Calculator Body - Classic wedge design */
 #calculator-body {
-    background: linear-gradient(145deg, #2a2a2a, #1a1a1a);
-    border-radius: 12px;
-    padding: 20px;
-    box-shadow: 
-        0 10px 40px rgba(0, 0, 0, 0.8),
-        inset 0 1px 0 rgba(255, 255, 255, 0.1);
-    border: 2px solid #0a0a0a;
+    width: 100%;
+    max-width: 420px;
+    background: linear-gradient(175deg,
+        #3d3832 0%,
+        #2a2520 15%,
+        #1f1b18 50%,
+        #1a1714 100%);
+    border-radius: 16px 16px 20px 20px;
+    padding: 0;
+    box-shadow:
+        0 25px 60px rgba(0, 0, 0, 0.8),
+        0 10px 30px rgba(0, 0, 0, 0.6),
+        inset 0 1px 0 rgba(255, 255, 255, 0.08),
+        inset 0 -2px 0 rgba(0, 0, 0, 0.3);
+    border: 1px solid #0a0908;
+    position: relative;
+    overflow: hidden;
 }
 
-.math {
-    font-family: 'Fraunces', monospace;
-    font-weight: 500;
-    font-style: italic;
+/* Subtle texture overlay */
+#calculator-body::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background:
+        repeating-linear-gradient(
+            0deg,
+            transparent,
+            transparent 2px,
+            rgba(0, 0, 0, 0.03) 2px,
+            rgba(0, 0, 0, 0.03) 4px
+        );
+    pointer-events: none;
+    border-radius: inherit;
 }
 
-/* Stack Display Area - HP Calculator Style */
-#stackDisplay {
-    font-family: 'Doto', monospace;
+/* HP Logo Header Area */
+#hp-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 18px 24px 14px 24px;
+    background: linear-gradient(180deg,
+        rgba(60, 55, 48, 0.6) 0%,
+        rgba(40, 36, 32, 0.4) 100%);
+    border-bottom: 1px solid rgba(0, 0, 0, 0.3);
+}
+
+.hp-logo {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.hp-letters {
+    font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    font-weight: 700;
+    font-size: 28px;
+    color: #b8a080;
+    text-transform: lowercase;
+    letter-spacing: -2px;
+    background: linear-gradient(180deg, #d4c4a8 0%, #a08860 100%);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+    text-shadow: none;
+    filter: drop-shadow(0 1px 1px rgba(0, 0, 0, 0.5));
+}
+
+.model-info {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+}
+
+.model-name {
+    font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    font-weight: 700;
+    font-size: 24px;
+    color: #c4a060;
+    letter-spacing: 1px;
+}
+
+.model-type {
+    font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
     font-weight: 400;
-    background-color: #0d0800;
-    border: 3px solid #0a0a0a;
+    font-size: 9px;
+    color: #8a7a60;
+    text-transform: uppercase;
+    letter-spacing: 1.5px;
+    margin-top: 2px;
+}
+
+/* Display Bezel - Metallic frame around display */
+#display-bezel {
+    margin: 16px 18px;
+    padding: 4px;
+    background: linear-gradient(180deg,
+        #5a5048 0%,
+        #3a3430 20%,
+        #2a2420 80%,
+        #4a4238 100%);
     border-radius: 6px;
-    padding: 12px 15px;
-    margin-bottom: 20px;
-    color: #ff9900;
-    box-shadow: 
-        inset 0 3px 10px rgba(0, 0, 0, 0.9),
-        inset 0 0 30px rgba(0, 0, 0, 0.5);
+    box-shadow:
+        inset 0 2px 4px rgba(0, 0, 0, 0.4),
+        0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+/* Stack Display Area - Vintage LED style */
+#stackDisplay {
+    font-family: 'Orbitron', 'Doto', monospace;
+    font-weight: 500;
+    background: linear-gradient(180deg, #0a0600 0%, #0d0800 50%, #080400 100%);
+    border: 2px solid #0a0a08;
+    border-radius: 4px;
+    padding: 14px 16px 10px 16px;
+    color: #ff6600;
+    box-shadow:
+        inset 0 4px 15px rgba(0, 0, 0, 0.9),
+        inset 0 0 40px rgba(0, 0, 0, 0.6),
+        inset 0 0 3px rgba(255, 102, 0, 0.1);
+    position: relative;
+    overflow: hidden;
+}
+
+/* LED Scanline effect */
+#stackDisplay::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: repeating-linear-gradient(
+        0deg,
+        transparent,
+        transparent 2px,
+        rgba(0, 0, 0, 0.15) 2px,
+        rgba(0, 0, 0, 0.15) 4px
+    );
+    pointer-events: none;
+}
+
+/* LED glow effect */
+#stackDisplay::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: radial-gradient(
+        ellipse at center,
+        rgba(255, 80, 0, 0.03) 0%,
+        transparent 70%
+    );
+    pointer-events: none;
 }
 
 .stack-row {
     display: flex;
     justify-content: space-between;
-    font-size: 14pt;
-    /* margin: 3px 0; */
+    font-size: 15px;
+    line-height: 1.5;
+    position: relative;
+    z-index: 1;
 }
 
 .stack-label {
-    min-width: 40px;
+    min-width: 50px;
     text-align: left;
+    color: #cc5500;
+    font-weight: 400;
+    font-size: 12px;
+    opacity: 0.8;
 }
 
 .stack-value {
-    width: 280px;
+    flex: 1;
     text-align: right;
-    padding-right: 10px;
-    font-weight: 800;
+    padding-right: 8px;
+    font-weight: 500;
+    font-size: 16px;
+    color: #ff7722;
+    text-shadow:
+        0 0 8px rgba(255, 102, 0, 0.6),
+        0 0 15px rgba(255, 60, 0, 0.3);
+    letter-spacing: 1px;
 }
 
-/* Dim the ENTRY label so it is less distracting */
+/* Entry row - slightly dimmer */
 .entry-label {
-    font-weight: 300;
-    color: #996600;
+    font-weight: 400;
+    color: #884400;
+    opacity: 0.7;
+}
+
+#entry-row .stack-value {
+    color: #ff8844;
+}
+
+/* Keyboard Section */
+#keyboard-section {
+    padding: 0 18px 20px 18px;
 }
 
 /* HP-67 calculator keyboard layout */
 #calcContainer {
     display: flex;
     flex-direction: column;
-    gap: 5px;
+    gap: 6px;
     margin: 0;
     padding: 0;
-}
-
-/* Remove old two-column styles */
-#functions, #numericButtons {
-    display: contents;
 }
 
 .button-row {
@@ -85,101 +242,392 @@ body {
     margin: 0;
 }
 
+/* Add visual separator before number pad */
+.button-row:nth-child(6) {
+    margin-top: 8px;
+    padding-top: 10px;
+    border-top: 1px solid rgba(80, 70, 55, 0.4);
+}
+
+/* Base button styles - Classic HP beveled keys */
 button {
-    font-family: 'Roboto Condensed', sans-serif;
+    font-family: 'Roboto Condensed', 'Helvetica Neue', sans-serif;
     font-weight: 600;
-    font-size: 0.75em;
-    background: linear-gradient(180deg, #4a4a4a 0%, #2a2a2a 100%);
-    color: #fff;
-    border: 1px solid #0a0a0a;
-    border-radius: 4px;
+    font-size: 11px;
+    background: linear-gradient(180deg,
+        #4a4540 0%,
+        #3a3530 40%,
+        #2a2520 60%,
+        #353025 100%);
+    color: #e8e0d0;
+    border: none;
+    border-radius: 5px;
     width: 100%;
-    min-width: 45px;
-    height: 38px;
+    height: 42px;
     cursor: pointer;
     margin: 0;
-    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.6), inset 0 1px 0 rgba(255, 255, 255, 0.15);
-    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.7);
-    transition: all 0.1s;
-    padding: 2px 4px;
+    box-shadow:
+        0 4px 0 #1a1815,
+        0 5px 3px rgba(0, 0, 0, 0.4),
+        inset 0 1px 0 rgba(255, 255, 255, 0.12),
+        inset 0 -1px 0 rgba(0, 0, 0, 0.2);
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.6);
+    transition: all 0.08s ease-out;
+    padding: 0 3px;
+    letter-spacing: 0.5px;
+    position: relative;
 }
 
 button:hover {
-    background: linear-gradient(180deg, #5a5a5a 0%, #3a3a3a 100%);
-    transform: translateY(-1px);
-    box-shadow: 0 3px 6px rgba(0, 0, 0, 0.7), inset 0 1px 0 rgba(255, 255, 255, 0.15);
+    background: linear-gradient(180deg,
+        #555048 0%,
+        #454038 40%,
+        #353028 60%,
+        #403830 100%);
+    box-shadow:
+        0 4px 0 #1a1815,
+        0 6px 5px rgba(0, 0, 0, 0.5),
+        inset 0 1px 0 rgba(255, 255, 255, 0.15),
+        inset 0 -1px 0 rgba(0, 0, 0, 0.2);
 }
 
 button:active {
-    transform: translateY(1px);
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.6), inset 0 1px 0 rgba(255, 255, 255, 0.1);
+    transform: translateY(3px);
+    box-shadow:
+        0 1px 0 #1a1815,
+        0 2px 2px rgba(0, 0, 0, 0.3),
+        inset 0 1px 0 rgba(255, 255, 255, 0.08),
+        inset 0 2px 4px rgba(0, 0, 0, 0.2);
 }
 
-/* Special button styles */
-.enter-btn {
-    grid-column: span 1;
+/* Math notation styling */
+.math {
+    font-family: 'Times New Roman', 'Fraunces', serif;
+    font-weight: 500;
+    font-style: italic;
+}
+
+button sup, button sub {
+    font-size: 0.7em;
+}
+
+/* Number keys - White/cream colored like vintage HP */
+button[data-action="0"],
+button[data-action="1"],
+button[data-action="2"],
+button[data-action="3"],
+button[data-action="4"],
+button[data-action="5"],
+button[data-action="6"],
+button[data-action="7"],
+button[data-action="8"],
+button[data-action="9"],
+button[data-action="."] {
+    background: linear-gradient(180deg,
+        #5a5550 0%,
+        #4a4540 40%,
+        #3a3530 60%,
+        #454035 100%);
+    color: #ffffff;
     font-weight: 700;
+    font-size: 14px;
 }
 
+button[data-action="0"]:hover,
+button[data-action="1"]:hover,
+button[data-action="2"]:hover,
+button[data-action="3"]:hover,
+button[data-action="4"]:hover,
+button[data-action="5"]:hover,
+button[data-action="6"]:hover,
+button[data-action="7"]:hover,
+button[data-action="8"]:hover,
+button[data-action="9"]:hover,
+button[data-action="."]:hover {
+    background: linear-gradient(180deg,
+        #656055 0%,
+        #555048 40%,
+        #454038 60%,
+        #504840 100%);
+}
+
+/* Operation buttons - Gold/Brown HP style */
+.opBtn {
+    background: linear-gradient(180deg,
+        #8a7040 0%,
+        #705828 40%,
+        #5a4820 60%,
+        #6a5830 100%);
+    color: #fff8e0;
+    font-weight: 700;
+    font-size: 16px;
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.5);
+    box-shadow:
+        0 4px 0 #3a3020,
+        0 5px 3px rgba(0, 0, 0, 0.4),
+        inset 0 1px 0 rgba(255, 255, 255, 0.2),
+        inset 0 -1px 0 rgba(0, 0, 0, 0.2);
+}
+
+.opBtn:hover {
+    background: linear-gradient(180deg,
+        #9a8050 0%,
+        #806838 40%,
+        #6a5830 60%,
+        #7a6840 100%);
+    box-shadow:
+        0 4px 0 #3a3020,
+        0 6px 5px rgba(0, 0, 0, 0.5),
+        inset 0 1px 0 rgba(255, 255, 255, 0.25),
+        inset 0 -1px 0 rgba(0, 0, 0, 0.2);
+}
+
+.opBtn:active {
+    box-shadow:
+        0 1px 0 #3a3020,
+        0 2px 2px rgba(0, 0, 0, 0.3),
+        inset 0 1px 0 rgba(255, 255, 255, 0.1),
+        inset 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+/* Function buttons - Olive/Khaki HP style */
+.fnBtn {
+    background: linear-gradient(180deg,
+        #605838 0%,
+        #504828 40%,
+        #403820 60%,
+        #4a4228 100%);
+    color: #e8e080;
+    font-weight: 600;
+    box-shadow:
+        0 4px 0 #282418,
+        0 5px 3px rgba(0, 0, 0, 0.4),
+        inset 0 1px 0 rgba(255, 255, 255, 0.12),
+        inset 0 -1px 0 rgba(0, 0, 0, 0.2);
+}
+
+.fnBtn:hover {
+    background: linear-gradient(180deg,
+        #706848 0%,
+        #605838 40%,
+        #504830 60%,
+        #5a5238 100%);
+    box-shadow:
+        0 4px 0 #282418,
+        0 6px 5px rgba(0, 0, 0, 0.5),
+        inset 0 1px 0 rgba(255, 255, 255, 0.15),
+        inset 0 -1px 0 rgba(0, 0, 0, 0.2);
+}
+
+.fnBtn:active {
+    box-shadow:
+        0 1px 0 #282418,
+        0 2px 2px rgba(0, 0, 0, 0.3),
+        inset 0 1px 0 rgba(255, 255, 255, 0.08),
+        inset 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+/* Memory buttons - Blue HP style */
+.memBtn {
+    background: linear-gradient(180deg,
+        #3a5068 0%,
+        #2a4058 40%,
+        #203048 60%,
+        #2a3a50 100%);
+    color: #90d0ff;
+    font-weight: 600;
+    box-shadow:
+        0 4px 0 #152030,
+        0 5px 3px rgba(0, 0, 0, 0.4),
+        inset 0 1px 0 rgba(255, 255, 255, 0.12),
+        inset 0 -1px 0 rgba(0, 0, 0, 0.2);
+}
+
+.memBtn:hover {
+    background: linear-gradient(180deg,
+        #4a6078 0%,
+        #3a5068 40%,
+        #304058 60%,
+        #3a4a60 100%);
+    box-shadow:
+        0 4px 0 #152030,
+        0 6px 5px rgba(0, 0, 0, 0.5),
+        inset 0 1px 0 rgba(255, 255, 255, 0.15),
+        inset 0 -1px 0 rgba(0, 0, 0, 0.2);
+}
+
+.memBtn:active {
+    box-shadow:
+        0 1px 0 #152030,
+        0 2px 2px rgba(0, 0, 0, 0.3),
+        inset 0 1px 0 rgba(255, 255, 255, 0.08),
+        inset 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+/* Other/Stack operation buttons - Tan/Brown */
+.otherBtn {
+    background: linear-gradient(180deg,
+        #5a4838 0%,
+        #4a3828 40%,
+        #3a2820 60%,
+        #443228 100%);
+    color: #ffcc88;
+    font-weight: 600;
+    font-size: 10px;
+    box-shadow:
+        0 4px 0 #201810,
+        0 5px 3px rgba(0, 0, 0, 0.4),
+        inset 0 1px 0 rgba(255, 255, 255, 0.12),
+        inset 0 -1px 0 rgba(0, 0, 0, 0.2);
+}
+
+.otherBtn:hover {
+    background: linear-gradient(180deg,
+        #6a5848 0%,
+        #5a4838 40%,
+        #4a3830 60%,
+        #544238 100%);
+    box-shadow:
+        0 4px 0 #201810,
+        0 6px 5px rgba(0, 0, 0, 0.5),
+        inset 0 1px 0 rgba(255, 255, 255, 0.15),
+        inset 0 -1px 0 rgba(0, 0, 0, 0.2);
+}
+
+.otherBtn:active {
+    box-shadow:
+        0 1px 0 #201810,
+        0 2px 2px rgba(0, 0, 0, 0.3),
+        inset 0 1px 0 rgba(255, 255, 255, 0.08),
+        inset 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+/* ENTER button - Special gold highlight */
+.enter-btn {
+    background: linear-gradient(180deg,
+        #7a6238 0%,
+        #604a20 40%,
+        #503a18 60%,
+        #5a4420 100%);
+    color: #ffe8a0;
+    font-weight: 700;
+    font-size: 10px;
+    letter-spacing: 0.3px;
+    box-shadow:
+        0 4px 0 #302810,
+        0 5px 3px rgba(0, 0, 0, 0.4),
+        inset 0 1px 0 rgba(255, 255, 255, 0.18),
+        inset 0 -1px 0 rgba(0, 0, 0, 0.2);
+}
+
+.enter-btn:hover {
+    background: linear-gradient(180deg,
+        #8a7248 0%,
+        #705a30 40%,
+        #604a28 60%,
+        #6a5430 100%);
+}
+
+/* Wide button styling */
 .wide-btn {
     grid-column: span 1;
 }
 
-/* HP-67 color-coded button categories */
-.opBtn {
-    background: linear-gradient(180deg, #6a5a3a 0%, #4a3a1a 100%);
-    color: #ffd700;
-    font-weight: 700;
-}
-
-.opBtn:hover {
-    background: linear-gradient(180deg, #7a6a4a 0%, #5a4a2a 100%);
-}
-
-.fnBtn {
-    background: linear-gradient(180deg, #5a5a2a 0%, #3a3a1a 100%);
-    color: #ffdd00;
-    font-weight: 600;
-}
-
-.fnBtn:hover {
-    background: linear-gradient(180deg, #6a6a3a 0%, #4a4a2a 100%);
-}
-
-.memBtn {
-    background: linear-gradient(180deg, #2a4a6a 0%, #1a3a4a 100%);
-    color: #66ccff;
-    font-weight: 600;
-}
-
-.memBtn:hover {
-    background: linear-gradient(180deg, #3a5a7a 0%, #2a4a5a 100%);
-}
-
-.otherBtn {
-    background: linear-gradient(180deg, #5a4a2a 0%, #3a2a1a 100%);
-    color: #ffaa00;
-    font-weight: 600;
-}
-
-.otherBtn:hover {
-    background: linear-gradient(180deg, #6a5a3a 0%, #4a3a2a 100%);
+/* Clear button - Red accent */
+button[data-action="CLR"] {
+    color: #ff9080;
 }
 
 /* Responsive Design */
-@media (max-width: 600px) {
+@media (max-width: 480px) {
     body {
-        max-width: 100%;
-        padding: 10px;
+        padding: 15px 10px;
     }
-    
+
     #calculator-body {
-        padding: 15px;
+        max-width: 100%;
+        border-radius: 12px 12px 16px 16px;
     }
-    
+
+    #hp-header {
+        padding: 14px 18px 10px 18px;
+    }
+
+    .hp-letters {
+        font-size: 24px;
+    }
+
+    .model-name {
+        font-size: 20px;
+    }
+
+    .model-type {
+        font-size: 8px;
+    }
+
+    #display-bezel {
+        margin: 12px 14px;
+    }
+
+    #keyboard-section {
+        padding: 0 14px 16px 14px;
+    }
+
     button {
-        font-size: 0.7em;
-        height: 36px;
-        min-width: 40px;
+        font-size: 10px;
+        height: 38px;
+    }
+
+    button[data-action="0"],
+    button[data-action="1"],
+    button[data-action="2"],
+    button[data-action="3"],
+    button[data-action="4"],
+    button[data-action="5"],
+    button[data-action="6"],
+    button[data-action="7"],
+    button[data-action="8"],
+    button[data-action="9"],
+    button[data-action="."] {
+        font-size: 13px;
+    }
+
+    .opBtn {
+        font-size: 14px;
+    }
+
+    .stack-value {
+        font-size: 14px;
+    }
+
+    .stack-label {
+        font-size: 11px;
+    }
+}
+
+@media (max-width: 360px) {
+    #hp-header {
+        padding: 12px 14px 8px 14px;
+    }
+
+    .hp-letters {
+        font-size: 20px;
+    }
+
+    .model-name {
+        font-size: 16px;
+    }
+
+    button {
+        font-size: 9px;
+        height: 34px;
+    }
+
+    .button-row {
+        gap: 3px;
+    }
+
+    #calcContainer {
+        gap: 4px;
     }
 }


### PR DESCRIPTION
- Add HP logo header with model name (67) and "Programmable Scientific" badge
- Create metallic bezel frame around LED-style display
- Add scanline and glow effects to display for vintage LED authenticity
- Redesign buttons with physical 3D beveled appearance using box-shadows
- Apply authentic HP color palette: gold operations, olive functions, blue memory
- Add subtle texture overlay to calculator body
- Improve button press animations with depth effect
- Add visual separator between function and number pad sections
- Update typography with Orbitron font for LED display
- Enhance responsive design for mobile devices